### PR TITLE
Add support for most recent LibNX and Atmosphère

### DIFF
--- a/420000000000000E/toolbox.json
+++ b/420000000000000E/toolbox.json
@@ -1,5 +1,0 @@
-{
-    "name"  : "sys-ftpd-10k",
-    "tid"   : "420000000000000E",
-    "requires_reboot": false
-}

--- a/Makefile
+++ b/Makefile
@@ -118,10 +118,10 @@ $(BUILD):
 	@[ -d $@ ] || mkdir -p $@
 	@$(MAKE) --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile
 	@rm -rf out
-	@mkdir -p out/atmosphere/contents/420000000000000E/flags
+	@mkdir -p out/atmosphere/contents/420000000000000F/flags
 	@mkdir -p out/config/$(TARGET)
-	@touch out/atmosphere/contents/420000000000000E/flags/boot2.flag
-	@cp $(TARGET).nsp out/atmosphere/contents/420000000000000E/exefs.nsp
+	@touch out/atmosphere/contents/420000000000000F/flags/boot2.flag
+	@cp $(TARGET).nsp out/atmosphere/contents/420000000000000F/exefs.nsp
 	@cp -r sd_card/. out/
 	@echo [DONE] $(TARGET) compiled successfully. All files have been placed in out/
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Hotkeys: To help with security while there is are no login credentials, debuggin
 
 ---
 
-Config Example (Located on your sd in `sdmc:/config/sys-ftpd/config.ini`):
+Config Example (Located on your sd in `sdmc:/config/sys-ftpd-10k/config.ini`):
 
 ```
 [User]

--- a/sd_card/atmosphere/contents/420000000000000E/toolbox.json
+++ b/sd_card/atmosphere/contents/420000000000000E/toolbox.json
@@ -1,5 +1,0 @@
-{
-    "name"  : "sys-ftpd-light",
-    "tid"   : "420000000000000E",
-    "requires_reboot": false
-}

--- a/sd_card/atmosphere/contents/420000000000000F/toolbox.json
+++ b/sd_card/atmosphere/contents/420000000000000F/toolbox.json
@@ -1,0 +1,5 @@
+{
+    "name"  : "sys-ftpd-10k",
+    "tid"   : "420000000000000F",
+    "requires_reboot": false
+}

--- a/sd_card/config/sys-ftpd/config.ini
+++ b/sd_card/config/sys-ftpd/config.ini
@@ -29,6 +29,12 @@ keycombo:=PLUS+MINUS+X
 # The list of valid keys is as follows:
 # A, B, X, Y, LS, RS, L, R, ZL, ZR, PLUS, MINUS, DLEFT, DUP, DRIGHT, DDOWN
 
+[Reboot]
+keycombo:=PLUS+MINUS+Y
+# keycombo:=  -> The key combination used to Generate error exception 12377. Each key is separated by either a plus '+' or a space ' '. Up to 8 keys are allowed.
+# The list of valid keys is as follows:
+# A, B, X, Y, LS, RS, L, R, ZL, ZR, PLUS, MINUS, DLEFT, DUP, DRIGHT, DDOWN
+
 [LED]
 led:=1
 

--- a/source/console.c
+++ b/source/console.c
@@ -25,7 +25,7 @@ void console_print(const char* fmt, ...)
 {
     if (should_log)
     {
-        stdout = stderr = fopen("/config/sys-ftpd/logs/ftpd.log", "a");
+        stdout = stderr = fopen("/config/sys-ftpd-10k/logs/ftpd.log", "a");
         va_list ap;
         va_start(ap, fmt);
         vprintf(fmt, ap);
@@ -38,7 +38,7 @@ void debug_print(const char* fmt, ...)
 {
     if (should_log)
     {
-        stdout = stderr = fopen("/config/sys-ftpd/logs/ftpd.log", "a");
+        stdout = stderr = fopen("/config/sys-ftpd-10k/logs/ftpd.log", "a");
 #ifdef ENABLE_LOGGING
         va_list ap;
         va_start(ap, fmt);

--- a/source/main.c
+++ b/source/main.c
@@ -55,8 +55,6 @@ void __appInit(void)
     setsysExit();
 
     static const SocketInitConfig socketInitConfig = {
-        .bsdsockets_version = 1,
-
         .tcp_tx_buf_size = 0x800,
         .tcp_rx_buf_size = 0x800,
         .tcp_tx_buf_max_size = 0x25000,
@@ -104,14 +102,14 @@ int main(int argc, char** argv)
     (void)argc;
     (void)argv;
 
-    FILE* should_log_file = fopen("/config/sys-ftpd/logs/ftpd_log_enabled", "r");
+    FILE* should_log_file = fopen("/config/sys-ftpd-10k/logs/ftpd_log_enabled", "r");
     if (should_log_file != NULL)
     {
         should_log = true;
         fclose(should_log_file);
 
-        mkdir("/config/sys-ftpd/logs", 0700);
-        unlink("/config/sys-ftpd/logs/ftpd.log");
+        mkdir("/config/sys-ftpd-10k/logs", 0700);
+        unlink("/config/sys-ftpd-10k/logs/ftpd.log");
     }
 
     char buffer[100];

--- a/source/util.c
+++ b/source/util.c
@@ -97,7 +97,7 @@ Result pauseInit()
     Result rc;
     mutexLock(&pausedMutex);
 
-    FILE* should_pause_file = fopen("/config/sys-ftpd/ftpd_paused", "r");
+    FILE* should_pause_file = fopen("/config/sys-ftpd-10k/ftpd_paused", "r");
     if (should_pause_file != NULL)
     {
         paused = true;
@@ -126,7 +126,7 @@ Result pauseInit()
 
     inputThreadRunning = true;
 
-    rc = threadCreate(&pauseThread, inputPoller, NULL, NULL, 0x300, 0x3B, -2);
+    rc = threadCreate(&pauseThread, inputPoller, NULL, NULL, 0x1000, 0x3B, -2);
     if (R_FAILED(rc))
         goto exit;
 
@@ -160,13 +160,13 @@ void setPaused(bool newPaused)
     paused = newPaused;
     if (paused)
     {
-        FILE* should_pause_file = fopen("/config/sys-ftpd/ftpd_paused", "w");
+        FILE* should_pause_file = fopen("/config/sys-ftpd-10k/ftpd_paused", "w");
         fclose(should_pause_file);
         flash_led_pause();
     }
     else
     {
-        unlink("/config/sys-ftpd/ftpd_paused");
+        unlink("/config/sys-ftpd-10k/ftpd_paused");
         flash_led_unpause();
     }
     mutexUnlock(&pausedMutex);

--- a/sys-ftpd.json
+++ b/sys-ftpd.json
@@ -1,8 +1,10 @@
 {
 	"name":	"sys-ftpd",
-	"title_id":	"0x420000000000000E",
-	"title_id_range_min":	"0x420000000000000E",
-	"title_id_range_max":	"0x420000000000000E",
+	"version":	"1.0.5b",
+	"program_id":	"0x420000000000000F",
+	"program_id_range_min":	"0x420000000000000F",
+	"program_id_range_max":	"0x420000000000000F",
+
 	"main_thread_stack_size":	"0x00004000",
 	"main_thread_priority":	49,
 	"default_cpu_id":	3,
@@ -10,7 +12,13 @@
 	"is_retail":	true,
 	"pool_partition":	2,
 	"is_64_bit":	true,
+	"signature_key_generation":	0,
 	"address_space_type":	3,
+	"optimize_memory_allocation":	false,
+	"disable_device_address_space_merge":	true,
+	"enable_alias_region_extra_size":	false,
+	"prevent_code_reads":	false,
+	"system_resource_size":	"0",
 	"filesystem_access":	{
 		"permissions":	"0xffffffffffffffff"
 	},
@@ -166,7 +174,8 @@
 			"type":	"debug_flags",
 			"value":	{
 				"allow_debug":	false,
-				"force_debug":	true
+				"force_debug":	true,
+				"force_debug_prod":	false
 			}
 		}]
 }


### PR DESCRIPTION
On this PR the next changes are proposed:

- Attempt to fix Switch Archive Bit, on file `source/ftp.c` a new code was added to deal with Archive Bit problems.

- `sys-ftpd.json` modded to comply with new standards of latest Firmware implemented by Atmosphère 1.8.0.


- The title ID `420000000000000F` and the config path `sys-ftpd-10k` is homogenized on all the code.

- the unneeded `/420000000000000E` folder is removed.